### PR TITLE
Update en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,8 @@ en:
     edit_shipping_address: "Edit Shipping Address"
     no_shipping_addresses_on_file: "No shipping addresses on file"
     shipping_addresses: "Shipping Addresses"
+    successfully_created: "Address has been successfully created."
+    successfully_removed: "Address has been successfully removed."
     successfully_saved: "Saved successfully"
     unsuccessfully_saved: "There was an error while trying to save your address."
     successfully_updated: "Updated successfully"


### PR DESCRIPTION
Both of these translations are called from the `addresses_controller.rb`, but are not defined in the translations.