### PR TITLE
On address update, only delete old uneditable address if new one is saved

### DIFF
--- a/app/controllers/spree/addresses_controller.rb
+++ b/app/controllers/spree/addresses_controller.rb
@@ -41,8 +41,8 @@ class Spree::AddressesController < Spree::StoreController
     else
       new_address = @address.clone
       new_address.attributes = address_params
-      @address.update_attribute(:deleted_at, Time.now)
       if new_address.save
+        @address.update_attribute(:deleted_at, Time.now)
         flash[:notice] = I18n.t(:successfully_updated, scope: :address_book)
         redirect_back_or_default(account_path)
       else


### PR DESCRIPTION
* Currently if you try and update an un-editable address, and there is an error on save, the old address still gets marked as deleted. If you then exit out of address editing you will have no addresses. 
* Moved the @address.update_attribute(:deleted_at, Time.now) code within the successful save block so that the old address is only marked as deleted if the new address saves properly. 