### PR TITLE
Ensure that the other address is always new

### DIFF
--- a/app/views/spree/checkout/_address.html.erb
+++ b/app/views/spree/checkout/_address.html.erb
@@ -30,12 +30,14 @@
             </p>
           </div>
           <% end %>
-          <%= form.fields_for address_name, @order.send("build_#{address_name}") do |address_form| %>
+          <% order_address_name = @order.send(address_name) %>
+          <%= form.fields_for address_name, order_address_name.valid? ? @order.send("build_#{address_name}") : order_address_name do |address_form| %>
             <div class="inner" data-hook=<%="#{address_type}_inner" %>>
               <%= render :partial => 'spree/addresses/form', :locals => {
                 :address_name => address_name,
                 :address_form => address_form,
-                :address_type => address_type
+                :address_type => address_type,
+                :address => order_address_name
               } %>
             </div>
           <% end %>

--- a/app/views/spree/checkout/_address.html.erb
+++ b/app/views/spree/checkout/_address.html.erb
@@ -30,13 +30,12 @@
             </p>
           </div>
           <% end %>
-          <%= form.fields_for address_name do |address_form| %>
+          <%= form.fields_for address_name, @order.send("build_#{address_name}") do |address_form| %>
             <div class="inner" data-hook=<%="#{address_type}_inner" %>>
               <%= render :partial => 'spree/addresses/form', :locals => {
                 :address_name => address_name,
                 :address_form => address_form,
-                :address_type => address_type,
-                :address => Spree::Address.default
+                :address_type => address_type
               } %>
             </div>
           <% end %>


### PR DESCRIPTION
If a user clicks the radio button to enter another address, this form was prefilled by spree default address for this user. This is NOT what we want. We want the address to always to be fresh.

Otherwise in conjuntion with the `Spree::UserAdress` module the preferred bill and shipping will be updated by the new address.

We almost always want to create a new temporary address, only when a validation error occurs we want to render the entered address.